### PR TITLE
Add ScriptComponent OnStart and animation-driven script control

### DIFF
--- a/Content/Documentation/WickedEngine-Documentation.md
+++ b/Content/Documentation/WickedEngine-Documentation.md
@@ -571,6 +571,11 @@ It is expected that an entity that has DecalComponent, also has TransformCompone
 #### AnimationComponent
 [[Header]](../../WickedEngine/wiScene_Components.h) [[Cpp]](../../WickedEngine/wiScene_Components.cpp)
 
+Animation channels can interact with ScriptComponents:
+
+- `SCRIPT_CALL` events invoke a script function by name when the keyframe is reached.
+- `SCRIPT_SET_VARIABLE` channels drive a numeric script variable over time.
+
 #### WeatherComponent
 [[Header]](../../WickedEngine/wiScene_Components.h) [[Cpp]](../../WickedEngine/wiScene_Components.cpp)
 
@@ -596,6 +601,15 @@ The collider component will specify a collider shape to be used in simple fake p
 #### ScriptComponent
 [[Header]](../../WickedEngine/wiScene_Components.h) [[Cpp]](../../WickedEngine/wiScene_Components.cpp)
 ScriptComponent can reference a lua script and run it every frame, while also providing some additional data to script like a local GetEntity() function. The script can be written to reference additional component data by using its unique GetEntity() function. A ScriptComponent can also call other scripts, which can be used to implement multiple scripts on one entity.
+
+Each component now keeps its own persistent lua state. When the component starts playing, the script is executed once and subsequent frames will reuse the same state. If the script defines an `Update()` function, it will be invoked automatically every frame.
+
+The component exposes helper methods for interacting with the stored state:
+
+- `OnStart()` &ndash; optional function called automatically the first time the component begins playing.
+- `CallFunction(name, ...)` &ndash; invoke a function inside the script by name with optional arguments.
+- `GetVariable(name)` &ndash; query a numeric global variable from the script.
+- `SetVariable(name, value)` &ndash; set a global variable inside the script state.
 
 #### Scene
 [[Header]](../../WickedEngine/wiScene.h) [[Cpp]](../../WickedEngine/wiScene.cpp)

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -2195,17 +2195,20 @@ namespace wi::scene
 							case AnimationComponent::AnimationChannel::Path::SOUND_STOP:
 								target_sound->Stop();
 								break;
-							case AnimationComponent::AnimationChannel::Path::SCRIPT_PLAY:
-								target_script->Play();
-								break;
-							case AnimationComponent::AnimationChannel::Path::SCRIPT_STOP:
-								target_script->Stop();
-								break;
-							default:
-								break;
-							}
-						}
-					}
+                                                        case AnimationComponent::AnimationChannel::Path::SCRIPT_PLAY:
+                                                                target_script->Play();
+                                                                break;
+                                                        case AnimationComponent::AnimationChannel::Path::SCRIPT_STOP:
+                                                                target_script->Stop();
+                                                                break;
+                                                       case AnimationComponent::AnimationChannel::Path::SCRIPT_CALL:
+                                                               target_script->CallFunction(channel.script_name);
+                                                               break;
+                                                        default:
+                                                                break;
+                                                        }
+                                                }
+                                        }
 					else
 					{
 						// Path data interpolation:
@@ -2652,11 +2655,11 @@ namespace wi::scene
 						}
 					}
 
-					if (target_camera != nullptr)
-					{
-						switch (channel.path)
-						{
-						case AnimationComponent::AnimationChannel::Path::CAMERA_FOV:
+                                        if (target_camera != nullptr)
+                                        {
+                                                switch (channel.path)
+                                                {
+                                                case AnimationComponent::AnimationChannel::Path::CAMERA_FOV:
 						{
 							target_camera->fov = wi::math::Lerp(target_camera->fov, interpolator.f, t);
 						}
@@ -2676,14 +2679,24 @@ namespace wi::scene
 							target_camera->aperture_shape = wi::math::Lerp(target_camera->aperture_shape, interpolator.f2, t);
 						}
 						break;
-						default:
-							break;
-						}
-					}
+                                                default:
+                                                        break;
+                                                }
+                                        }
 
-					if (target_material != nullptr)
-					{
-						target_material->SetDirty();
+                                        if (target_script != nullptr)
+                                        {
+                                                if (channel.path == AnimationComponent::AnimationChannel::Path::SCRIPT_SET_VARIABLE)
+                                                {
+                                                        double current = target_script->GetVariable(channel.script_name);
+                                                        double result = wi::math::Lerp(current, (double)interpolator.f, t);
+                                                        target_script->SetVariable(channel.script_name, ScriptComponent::ScriptParam(result));
+                                                }
+                                        }
+
+                                        if (target_material != nullptr)
+                                        {
+                                                target_material->SetDirty();
 
 						switch (channel.path)
 						{
@@ -5440,29 +5453,55 @@ namespace wi::scene
 			ScriptComponent& script = scripts[i];
 			Entity entity = scripts.GetEntity(i);
 
-			if (script.IsPlaying())
-			{
-				if (script.resource.IsValid() && (script.script.empty() || script.script_hash != script.resource.GetScriptHash()))
-				{
-					script.script.clear();
-					script.script_hash = script.resource.GetScriptHash();
-					std::string str = script.resource.GetScript();
-					wi::lua::AttachScriptParameters(str, script.filename, wi::lua::GeneratePID(), "local function GetEntity() return " + std::to_string(entity) + "; end;", "");
-					wi::lua::CompileText(str, script.script);
-				}
-				if (!script.script.empty())
-				{
-					wi::lua::RunBinaryData(script.script.data(), script.script.size(), script.filename.c_str());
-				}
+                       if (script.IsPlaying())
+                       {
+                               if (script.resource.IsValid() && (script.instance == nullptr || script.script_hash != script.resource.GetScriptHash()))
+                               {
+                                       script.script_hash = script.resource.GetScriptHash();
+                                       std::string str = script.resource.GetScript();
+                                       wi::lua::AttachScriptParameters(str, script.filename, wi::lua::GeneratePID(), "local function GetEntity() return " + std::to_string(entity) + "; end;", "");
 
-				if (script.IsPlayingOnlyOnce())
-				{
-					script.Stop();
-				}
-			}
-		}
-		wi::profiler::EndRange(range);
-	}
+                                       lua_State* L = wi::lua::GetLuaState();
+                                       script.instance = lua_newthread(L);
+                                       lua_newtable(script.instance);
+                                       lua_newtable(script.instance);
+                                       lua_pushglobaltable(script.instance);
+                                       lua_setfield(script.instance, -2, "__index");
+                                       lua_setmetatable(script.instance, -2);
+                                       lua_rawseti(script.instance, LUA_REGISTRYINDEX, LUA_RIDX_GLOBALS);
+
+                                       if (luaL_loadbuffer(script.instance, str.c_str(), str.length(), script.filename.c_str()) == LUA_OK)
+                                       {
+                                               if (lua_pcall(script.instance, 0, 0, 0) != LUA_OK)
+                                               {
+                                                       wi::lua::PostErrorMsg(script.instance);
+                                               }
+                                       }
+                                       else
+                                       {
+                                               wi::lua::PostErrorMsg(script.instance);
+                                       }
+                               }
+
+                               if (script.instance != nullptr)
+                               {
+                                       if (!(script._flags & ScriptComponent::STARTED))
+                                       {
+                                               script.CallFunction("OnStart");
+                                               script._flags |= ScriptComponent::STARTED;
+                                       }
+
+                                       script.CallFunction("Update");
+
+                                       if (script.IsPlayingOnlyOnce())
+                                       {
+                                               script.Stop();
+                                       }
+                               }
+                       }
+               }
+               wi::profiler::EndRange(range);
+       }
 	void Scene::RunSpriteUpdateSystem(wi::jobsystem::context& ctx)
 	{
 		wi::jobsystem::Dispatch(ctx, (uint32_t)sprites.GetCount(), small_subtask_groupsize, [&](wi::jobsystem::JobArgs args) {

--- a/WickedEngine/wiScene_BindLua.cpp
+++ b/WickedEngine/wiScene_BindLua.cpp
@@ -6368,12 +6368,15 @@ int SpringComponent_BindLua::GetWindAffection(lua_State* L)
 
 
 Luna<ScriptComponent_BindLua>::FunctionType ScriptComponent_BindLua::methods[] = {
-	lunamethod(ScriptComponent_BindLua, CreateFromFile),
-	lunamethod(ScriptComponent_BindLua, Play),
-	lunamethod(ScriptComponent_BindLua, IsPlaying),
-	lunamethod(ScriptComponent_BindLua, SetPlayOnce),
-	lunamethod(ScriptComponent_BindLua, Stop),
-	{ NULL, NULL }
+        lunamethod(ScriptComponent_BindLua, CreateFromFile),
+        lunamethod(ScriptComponent_BindLua, Play),
+       lunamethod(ScriptComponent_BindLua, IsPlaying),
+       lunamethod(ScriptComponent_BindLua, SetPlayOnce),
+       lunamethod(ScriptComponent_BindLua, Stop),
+       lunamethod(ScriptComponent_BindLua, CallFunction),
+       lunamethod(ScriptComponent_BindLua, GetVariable),
+       lunamethod(ScriptComponent_BindLua, SetVariable),
+        { NULL, NULL }
 };
 Luna<ScriptComponent_BindLua>::PropertyType ScriptComponent_BindLua::properties[] = {
 	{ NULL, NULL }
@@ -6415,8 +6418,86 @@ int ScriptComponent_BindLua::SetPlayOnce(lua_State* L)
 }
 int ScriptComponent_BindLua::Stop(lua_State* L)
 {
-	component->Stop();
-	return 0;
+        component->Stop();
+        return 0;
+}
+
+int ScriptComponent_BindLua::CallFunction(lua_State* L)
+{
+       int argc = wi::lua::SGetArgCount(L);
+       if (argc > 0)
+       {
+               std::string name = wi::lua::SGetString(L, 1);
+               wi::vector<wi::scene::ScriptComponent::ScriptParam> params;
+               for (int i = 2; i <= argc; ++i)
+               {
+                       switch (wi::lua::SGetType(L, i))
+                       {
+                       case LUA_TNUMBER:
+                               params.emplace_back(wi::lua::SGetDouble(L, i));
+                               break;
+                       case LUA_TBOOLEAN:
+                               params.emplace_back(wi::lua::SGetBool(L, i));
+                               break;
+                       case LUA_TSTRING:
+                               params.emplace_back(std::string(wi::lua::SGetString(L, i)));
+                               break;
+                       default:
+                               params.emplace_back(); // nil
+                               break;
+                       }
+               }
+               component->CallFunction(name, params);
+       }
+       else
+       {
+               wi::lua::SError(L, "CallFunction(string name) not enough arguments!");
+       }
+       return 0;
+}
+
+int ScriptComponent_BindLua::GetVariable(lua_State* L)
+{
+        int argc = wi::lua::SGetArgCount(L);
+        if (argc > 0)
+        {
+                double value = component->GetVariable(wi::lua::SGetString(L, 1));
+                wi::lua::SSetDouble(L, value);
+                return 1;
+        }
+        wi::lua::SError(L, "GetVariable(string name) not enough arguments!");
+        return 0;
+}
+
+int ScriptComponent_BindLua::SetVariable(lua_State* L)
+{
+       int argc = wi::lua::SGetArgCount(L);
+       if (argc > 1)
+       {
+               std::string name = wi::lua::SGetString(L, 1);
+               wi::scene::ScriptComponent::ScriptParam param;
+               switch (wi::lua::SGetType(L, 2))
+               {
+               case LUA_TNUMBER:
+                       param = wi::scene::ScriptComponent::ScriptParam(wi::lua::SGetDouble(L, 2));
+                       break;
+               case LUA_TBOOLEAN:
+                       param = wi::scene::ScriptComponent::ScriptParam(wi::lua::SGetBool(L, 2));
+                       break;
+               case LUA_TSTRING:
+                       param = wi::scene::ScriptComponent::ScriptParam(std::string(wi::lua::SGetString(L, 2)));
+                       break;
+               default:
+                       param = wi::scene::ScriptComponent::ScriptParam();
+                       break;
+               }
+               component->SetVariable(name, param);
+       }
+       else
+       {
+               wi::lua::SError(L, "SetVariable(string name, value) not enough arguments!");
+       }
+       return 0;
 }
 
 

--- a/WickedEngine/wiScene_BindLua.h
+++ b/WickedEngine/wiScene_BindLua.h
@@ -978,14 +978,17 @@ namespace wi::lua::scene
 		static Luna<ScriptComponent_BindLua>::PropertyType properties[];
 
 		ScriptComponent_BindLua(wi::scene::ScriptComponent* component) :component(component) {}
-		ScriptComponent_BindLua(lua_State* L) : component(&owning) {}
+                ScriptComponent_BindLua(lua_State* L) : component(&owning) {}
 
-		int CreateFromFile(lua_State* L);
-		int Play(lua_State* L);
-		int IsPlaying(lua_State* L);
-		int SetPlayOnce(lua_State* L);
-		int Stop(lua_State* L);
-	};
+                int CreateFromFile(lua_State* L);
+               int Play(lua_State* L);
+               int IsPlaying(lua_State* L);
+               int SetPlayOnce(lua_State* L);
+               int Stop(lua_State* L);
+               int CallFunction(lua_State* L);
+               int GetVariable(lua_State* L);
+               int SetVariable(lua_State* L);
+       };
 
 	class RigidBodyPhysicsComponent_BindLua
 	{

--- a/WickedEngine/wiScene_Components.cpp
+++ b/WickedEngine/wiScene_Components.cpp
@@ -2288,9 +2288,12 @@ namespace wi::scene
 		case wi::scene::AnimationComponent::AnimationChannel::Path::CAMERA_APERTURE_SHAPE:
 			return PathDataType::Float2;
 
-		case wi::scene::AnimationComponent::AnimationChannel::Path::SCRIPT_PLAY:
-		case wi::scene::AnimationComponent::AnimationChannel::Path::SCRIPT_STOP:
-			return PathDataType::Event;
+               case wi::scene::AnimationComponent::AnimationChannel::Path::SCRIPT_PLAY:
+               case wi::scene::AnimationComponent::AnimationChannel::Path::SCRIPT_STOP:
+               case wi::scene::AnimationComponent::AnimationChannel::Path::SCRIPT_CALL:
+                       return PathDataType::Event;
+               case wi::scene::AnimationComponent::AnimationChannel::Path::SCRIPT_SET_VARIABLE:
+                       return PathDataType::Float;
 
 		case wi::scene::AnimationComponent::AnimationChannel::Path::MATERIAL_COLOR:
 		case wi::scene::AnimationComponent::AnimationChannel::Path::MATERIAL_EMISSIVE:
@@ -2672,12 +2675,102 @@ namespace wi::scene
 		aperture_shape = wi::math::Lerp(a.aperture_shape, b.aperture_shape, t);
 	}
 
-	void ScriptComponent::CreateFromFile(const std::string& filename)
-	{
-		this->filename = filename;
-		resource = wi::resourcemanager::Load(filename);
-		script.clear(); // will be created on first Update()
-	}
+void ScriptComponent::CreateFromFile(const std::string& filename)
+{
+        this->filename = filename;
+        resource = wi::resourcemanager::Load(filename);
+        script.clear(); // will be created on first Update()
+}
+
+void ScriptComponent::CallFunction(const std::string& name) const
+{
+        CallFunction(name, {});
+}
+
+void ScriptComponent::CallFunction(const std::string& name, const wi::vector<ScriptParam>& params) const
+{
+        if (instance == nullptr)
+                return;
+
+        lua_getglobal(instance, name.c_str());
+        if (lua_isfunction(instance, -1))
+        {
+                for (const ScriptParam& p : params)
+                {
+                        switch (p.type)
+                        {
+                        case ScriptParam::Type::INT:
+                                wi::lua::SSetInt(instance, p.i);
+                                break;
+                        case ScriptParam::Type::FLOAT:
+                                wi::lua::SSetFloat(instance, p.f);
+                                break;
+                        case ScriptParam::Type::DOUBLE:
+                                wi::lua::SSetDouble(instance, p.d);
+                                break;
+                        case ScriptParam::Type::STRING:
+                                wi::lua::SSetString(instance, p.s.c_str());
+                                break;
+                        case ScriptParam::Type::BOOL:
+                                wi::lua::SSetBool(instance, p.b);
+                                break;
+                        default:
+                                wi::lua::SSetNull(instance);
+                                break;
+                        }
+                }
+
+                if (lua_pcall(instance, (int)params.size(), 0, 0) != LUA_OK)
+                {
+                        wi::lua::PostErrorMsg(instance);
+                }
+        }
+        else
+        {
+                lua_pop(instance, 1);
+        }
+}
+
+double ScriptComponent::GetVariable(const std::string& name) const
+{
+        if (instance == nullptr)
+                return 0;
+
+        lua_getglobal(instance, name.c_str());
+        double value = wi::lua::SGetDouble(instance, -1);
+        lua_pop(instance, 1);
+        return value;
+}
+
+void ScriptComponent::SetVariable(const std::string& name, const ScriptParam& param) const
+{
+       if (instance == nullptr)
+               return;
+
+       switch (param.type)
+       {
+       case ScriptParam::Type::INT:
+               wi::lua::SSetInt(instance, param.i);
+               break;
+       case ScriptParam::Type::FLOAT:
+               wi::lua::SSetFloat(instance, param.f);
+               break;
+       case ScriptParam::Type::DOUBLE:
+               wi::lua::SSetDouble(instance, param.d);
+               break;
+       case ScriptParam::Type::STRING:
+               wi::lua::SSetString(instance, param.s.c_str());
+               break;
+       case ScriptParam::Type::BOOL:
+               wi::lua::SSetBool(instance, param.b);
+               break;
+       default:
+               wi::lua::SSetNull(instance);
+               break;
+       }
+
+       lua_setglobal(instance, name.c_str());
+}
 
 	void SoundComponent::Play()
 	{

--- a/WickedEngine/wiScene_Components.h
+++ b/WickedEngine/wiScene_Components.h
@@ -17,6 +17,8 @@
 #include "wiPathQuery.h"
 #include "wiAllocator.h"
 
+struct lua_State;
+
 namespace wi::scene
 {
 
@@ -1675,14 +1677,16 @@ namespace wi::scene
 				CAMERA_FOV,
 				CAMERA_FOCAL_LENGTH,
 				CAMERA_APERTURE_SIZE,
-				CAMERA_APERTURE_SHAPE,
-				// additional camera paths can go here...
-				_CAMERA_RANGE_END = CAMERA_FOV + 1000,
+                                CAMERA_APERTURE_SHAPE,
+                                // additional camera paths can go here...
+                                _CAMERA_RANGE_END = CAMERA_FOV + 1000,
 
-				SCRIPT_PLAY,
-				SCRIPT_STOP,
-				// additional script paths can go here...
-				_SCRIPT_RANGE_END = SCRIPT_PLAY + 1000,
+                                SCRIPT_PLAY,
+                                SCRIPT_STOP,
+                                SCRIPT_CALL,
+                                SCRIPT_SET_VARIABLE,
+                                // additional script paths can go here...
+                                _SCRIPT_RANGE_END = SCRIPT_PLAY + 1000,
 
 				MATERIAL_COLOR,
 				MATERIAL_EMISSIVE,
@@ -1696,22 +1700,23 @@ namespace wi::scene
 				UNKNOWN,
 			} path = Path::UNKNOWN;
 
-			enum class PathDataType
-			{
-				Event,
-				Float,
-				Float2,
-				Float3,
-				Float4,
-				Weights,
+                        enum class PathDataType
+                        {
+                                Event,
+                                Float,
+                                Float2,
+                                Float3,
+                                Float4,
+                                Weights,
 
-				Count,
-			};
-			PathDataType GetPathDataType() const;
+                                Count,
+                        };
+                        PathDataType GetPathDataType() const;
 
-			// Non-serialized attributes:
-			mutable int next_event = 0;
-		};
+                        // Non-serialized attributes:
+                        mutable int next_event = 0;
+                        std::string script_name;
+                };
 		struct AnimationSampler
 		{
 			enum FLAGS
@@ -2040,34 +2045,84 @@ namespace wi::scene
 		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
 	};
 
-	struct ScriptComponent
-	{
-		enum FLAGS
-		{
-			EMPTY = 0,
-			PLAYING = 1 << 0,
-			PLAY_ONCE = 1 << 1,
-		};
-		uint32_t _flags = EMPTY;
+        struct ScriptComponent
+        {
+                enum FLAGS
+                {
+                        EMPTY = 0,
+                        PLAYING = 1 << 0,
+                        PLAY_ONCE = 1 << 1,
+                        STARTED = 1 << 2,
+                };
+                uint32_t _flags = EMPTY;
 
 		std::string filename;
 
 		// Non-serialized attributes:
-		wi::vector<uint8_t> script; // compiled script binary data
-		wi::Resource resource;
-		size_t script_hash = 0;
+               wi::vector<uint8_t> script; // compiled script binary data
+               wi::Resource resource;
+               size_t script_hash = 0;
 
-		constexpr void Play() { _flags |= PLAYING; }
-		constexpr void SetPlayOnce(bool once = true) { if (once) { _flags |= PLAY_ONCE; } else { _flags &= ~PLAY_ONCE; } }
-		constexpr void Stop() { _flags &= ~PLAYING; }
+               // Persistent lua state for this component:
+               lua_State* instance = nullptr;
+
+                constexpr void Play() { _flags |= PLAYING; _flags &= ~STARTED; }
+                constexpr void SetPlayOnce(bool once = true) { if (once) { _flags |= PLAY_ONCE; } else { _flags &= ~PLAY_ONCE; } }
+                constexpr void Stop() { _flags &= ~PLAYING; }
 
 		constexpr bool IsPlaying() const { return _flags & PLAYING; }
 		constexpr bool IsPlayingOnlyOnce() const { return _flags & PLAY_ONCE; }
 
-		void CreateFromFile(const std::string& filename);
+               void CreateFromFile(const std::string& filename);
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
-	};
+               struct ScriptParam
+               {
+                       enum class Type
+                       {
+                               NIL,
+                               INT,
+                               FLOAT,
+                               DOUBLE,
+                               STRING,
+                               BOOL,
+                       };
+                       Type type = Type::NIL;
+                       int i = 0;
+                       float f = 0;
+                       double d = 0;
+                       bool b = false;
+                       std::string s;
+                       ScriptParam() = default;
+                       ScriptParam(int v) : type(Type::INT), i(v) {}
+                       ScriptParam(float v) : type(Type::FLOAT), f(v) {}
+                       ScriptParam(double v) : type(Type::DOUBLE), d(v) {}
+                       ScriptParam(bool v) : type(Type::BOOL), b(v) {}
+                       ScriptParam(const std::string& v) : type(Type::STRING), s(v) {}
+                       ScriptParam(const char* v) : type(Type::STRING), s(v) {}
+               };
+
+               // Invoke a lua function from the stored state with optional arguments
+               void CallFunction(const std::string& name) const;
+               void CallFunction(const std::string& name, const wi::vector<ScriptParam>& params) const;
+               template<typename... Args>
+               void CallFunction(const std::string& name, Args... args) const
+               {
+                       wi::vector<ScriptParam> params;
+                       params.reserve(sizeof...(args));
+                       (params.emplace_back(args), ...);
+                       CallFunction(name, params);
+               }
+
+               // Retrieve a numeric global variable from the stored state
+               double GetVariable(const std::string& name) const;
+
+               // Set a global variable in the stored state
+               void SetVariable(const std::string& name, const ScriptParam& param) const;
+               template<typename T>
+               void SetVariable(const std::string& name, T value) const { SetVariable(name, ScriptParam(value)); }
+
+               void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+       };
 
 	struct ExpressionComponent
 	{


### PR DESCRIPTION
## Summary
- Automatically invoke optional OnStart when a ScriptComponent begins playing
- Allow scripts to modify globals via new SetVariable helper and Lua binding
- Enable animations to call script functions or drive script variables through new channel paths

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SDL2")*
- `cmake --build build -j2` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68a6064b1afc8327a37c4399cb0fdf30