### PR TITLE
Add basic node editor window

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1116,20 +1116,20 @@ void EditorComponent::Load()
 	});
 	topmenuWnd.AddWidget(&profilerButton);
 
-	nodeEditorButton.Create("Node Editor");
-	nodeEditorButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
-	nodeEditorButton.SetShadowRadius(2);
-	nodeEditorButton.font.params.shadowColor = wi::Color::Transparent();
-	nodeEditorButton.SetTooltip("Open the node editor");
-	nodeEditorButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
-	nodeEditorButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
-	nodeEditorButton.OnClick([this](wi::gui::EventArgs args) {
-		nodeEditorWnd.SetVisible(!nodeEditorWnd.IsVisible());
-	});
-	topmenuWnd.AddWidget(&nodeEditorButton);
+       nodeEditorButton.Create(ICON_SOFT);
+       nodeEditorButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
+       nodeEditorButton.SetShadowRadius(2);
+       nodeEditorButton.font.params.shadowColor = wi::Color::Transparent();
+       nodeEditorButton.SetTooltip("Open the node editor");
+       nodeEditorButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
+       nodeEditorButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
+       nodeEditorButton.OnClick([this](wi::gui::EventArgs args) {
+               nodeEditorWnd.SetVisible(!nodeEditorWnd.IsVisible());
+       });
+       GetGUI().AddWidget(&nodeEditorButton);
 
 
-	cinemaButton.Create(ICON_CINEMA_MODE);
+       cinemaButton.Create(ICON_CINEMA_MODE);
 	cinemaButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
 	cinemaButton.SetShadowRadius(2);
 	cinemaButton.font.params.shadowColor = wi::Color::Transparent();
@@ -5814,13 +5814,18 @@ void EditorComponent::UpdateDynamicWidgets()
 	navtestButton.Update(*this, 0);
 	y += navtestButton.GetSize().y + padding;
 
-	cinemaButton.SetSize(XMFLOAT2(hei, hei));
-	cinemaButton.SetPos(XMFLOAT2(ofs, y));
-	cinemaButton.Update(*this, 0);
-	y += cinemaButton.GetSize().y + padding;
+       cinemaButton.SetSize(XMFLOAT2(hei, hei));
+       cinemaButton.SetPos(XMFLOAT2(ofs, y));
+       cinemaButton.Update(*this, 0);
+       y += cinemaButton.GetSize().y + padding;
+
+        nodeEditorButton.SetSize(XMFLOAT2(hei, hei));
+        nodeEditorButton.SetPos(XMFLOAT2(ofs, y));
+        nodeEditorButton.Update(*this, 0);
+        y += nodeEditorButton.GetSize().y + padding;
 
 
-	newEntityCombo.SetSize(XMFLOAT2(hei * 1.4f, hei * 1.4f));
+       newEntityCombo.SetSize(XMFLOAT2(hei * 1.4f, hei * 1.4f));
 	ofs -= padding * 2 + newEntityCombo.GetSize().x;
 	y = topmenuWnd.GetSize().y + padding;
 	newEntityCombo.SetPos(XMFLOAT2(ofs, y));

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1116,6 +1116,18 @@ void EditorComponent::Load()
 	});
 	topmenuWnd.AddWidget(&profilerButton);
 
+	nodeEditorButton.Create("Node Editor");
+	nodeEditorButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
+	nodeEditorButton.SetShadowRadius(2);
+	nodeEditorButton.font.params.shadowColor = wi::Color::Transparent();
+	nodeEditorButton.SetTooltip("Open the node editor");
+	nodeEditorButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
+	nodeEditorButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
+	nodeEditorButton.OnClick([this](wi::gui::EventArgs args) {
+		nodeEditorWnd.SetVisible(!nodeEditorWnd.IsVisible());
+	});
+	topmenuWnd.AddWidget(&nodeEditorButton);
+
 
 	cinemaButton.Create(ICON_CINEMA_MODE);
 	cinemaButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
@@ -1333,6 +1345,9 @@ void EditorComponent::Load()
 
 	themeEditorWnd.Create(this);
 	GetGUI().AddWidget(&themeEditorWnd);
+
+	nodeEditorWnd.Create(this);
+	GetGUI().AddWidget(&nodeEditorWnd);
 
 	SetDefaultLocalization();
 	generalWnd.RefreshLanguageSelectionAfterWholeGUIWasInitialized();

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1116,20 +1116,20 @@ void EditorComponent::Load()
 	});
 	topmenuWnd.AddWidget(&profilerButton);
 
-       nodeEditorButton.Create(ICON_SOFT);
-       nodeEditorButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
-       nodeEditorButton.SetShadowRadius(2);
-       nodeEditorButton.font.params.shadowColor = wi::Color::Transparent();
-       nodeEditorButton.SetTooltip("Open the node editor");
-       nodeEditorButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
-       nodeEditorButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
-       nodeEditorButton.OnClick([this](wi::gui::EventArgs args) {
-               nodeEditorWnd.SetVisible(!nodeEditorWnd.IsVisible());
-       });
-       GetGUI().AddWidget(&nodeEditorButton);
+    nodeEditorButton.Create(ICON_SOFT);
+    nodeEditorButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
+    nodeEditorButton.SetShadowRadius(2);
+    nodeEditorButton.font.params.shadowColor = wi::Color::Transparent();
+    nodeEditorButton.SetTooltip("Open the node editor");
+    nodeEditorButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
+    nodeEditorButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
+    nodeEditorButton.OnClick([this](wi::gui::EventArgs args) {
+            nodeEditorWnd.SetVisible(!nodeEditorWnd.IsVisible());
+    });
+    GetGUI().AddWidget(&nodeEditorButton);
 
 
-       cinemaButton.Create(ICON_CINEMA_MODE);
+    cinemaButton.Create(ICON_CINEMA_MODE);
 	cinemaButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
 	cinemaButton.SetShadowRadius(2);
 	cinemaButton.font.params.shadowColor = wi::Color::Transparent();
@@ -5814,15 +5814,15 @@ void EditorComponent::UpdateDynamicWidgets()
 	navtestButton.Update(*this, 0);
 	y += navtestButton.GetSize().y + padding;
 
-       cinemaButton.SetSize(XMFLOAT2(hei, hei));
-       cinemaButton.SetPos(XMFLOAT2(ofs, y));
-       cinemaButton.Update(*this, 0);
-       y += cinemaButton.GetSize().y + padding;
+    cinemaButton.SetSize(XMFLOAT2(hei, hei));
+    cinemaButton.SetPos(XMFLOAT2(ofs, y));
+    cinemaButton.Update(*this, 0);
+    y += cinemaButton.GetSize().y + padding;
 
-        nodeEditorButton.SetSize(XMFLOAT2(hei, hei));
-        nodeEditorButton.SetPos(XMFLOAT2(ofs, y));
-        nodeEditorButton.Update(*this, 0);
-        y += nodeEditorButton.GetSize().y + padding;
+	nodeEditorButton.SetSize(XMFLOAT2(hei, hei));
+	nodeEditorButton.SetPos(XMFLOAT2(ofs, y));
+	nodeEditorButton.Update(*this, 0);
+	y += nodeEditorButton.GetSize().y + padding;
 
 
        newEntityCombo.SetSize(XMFLOAT2(hei * 1.4f, hei * 1.4f));

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -6,6 +6,7 @@
 #include "ContentBrowserWindow.h"
 #include "ProjectCreatorWindow.h"
 #include "ThemeEditorWindow.h"
+#include "NodeEditorWindow.h"
 #include "GraphicsWindow.h"
 #include "CameraWindow.h"
 #include "MaterialPickerWindow.h"
@@ -53,9 +54,10 @@ public:
 	wi::gui::Button saveButton;
 	wi::gui::Button openButton;
 	wi::gui::Button contentBrowserButton;
-	wi::gui::Button logButton;
-	wi::gui::Button profilerButton;
-	wi::gui::Button cinemaButton;
+        wi::gui::Button logButton;
+        wi::gui::Button profilerButton;
+        wi::gui::Button nodeEditorButton;
+        wi::gui::Button cinemaButton;
 	wi::gui::Button fullscreenButton;
 	wi::gui::Button bugButton;
 	wi::gui::Button aboutButton;
@@ -66,9 +68,10 @@ public:
 	ComponentsWindow componentsWnd;
 	ProfilerWindow profilerWnd;
 	ContentBrowserWindow contentBrowserWnd;
-	ProjectCreatorWindow projectCreatorWnd;
-	ThemeEditorWindow themeEditorWnd;
-	wi::gui::Window topmenuWnd;
+        ProjectCreatorWindow projectCreatorWnd;
+        ThemeEditorWindow themeEditorWnd;
+        NodeEditorWindow nodeEditorWnd;
+        wi::gui::Window topmenuWnd;
 
 	wi::gui::Button generalButton;
 	wi::gui::Button graphicsButton;

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -54,10 +54,10 @@ public:
 	wi::gui::Button saveButton;
 	wi::gui::Button openButton;
 	wi::gui::Button contentBrowserButton;
-        wi::gui::Button logButton;
-        wi::gui::Button profilerButton;
-        wi::gui::Button nodeEditorButton;
-        wi::gui::Button cinemaButton;
+    wi::gui::Button logButton;
+    wi::gui::Button profilerButton;
+    wi::gui::Button nodeEditorButton;
+    wi::gui::Button cinemaButton;
 	wi::gui::Button fullscreenButton;
 	wi::gui::Button bugButton;
 	wi::gui::Button aboutButton;
@@ -68,10 +68,10 @@ public:
 	ComponentsWindow componentsWnd;
 	ProfilerWindow profilerWnd;
 	ContentBrowserWindow contentBrowserWnd;
-        ProjectCreatorWindow projectCreatorWnd;
-        ThemeEditorWindow themeEditorWnd;
-        NodeEditorWindow nodeEditorWnd;
-        wi::gui::Window topmenuWnd;
+    ProjectCreatorWindow projectCreatorWnd;
+    ThemeEditorWindow themeEditorWnd;
+    NodeEditorWindow nodeEditorWnd;
+    wi::gui::Window topmenuWnd;
 
 	wi::gui::Button generalButton;
 	wi::gui::Button graphicsButton;

--- a/Editor/Editor_SOURCE.vcxitems
+++ b/Editor/Editor_SOURCE.vcxitems
@@ -44,6 +44,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ModelImporter_GLTF.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ModelImporter_OBJ.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)NameWindow.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)NodeEditorWindow.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ObjectWindow.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)PaintToolWindow.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)GraphicsWindow.cpp" />
@@ -119,6 +120,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)MetadataWindow.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ModelImporter.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)NameWindow.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)NodeEditorWindow.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ObjectWindow.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PaintToolWindow.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)GraphicsWindow.h" />

--- a/Editor/Editor_SOURCE.vcxitems.filters
+++ b/Editor/Editor_SOURCE.vcxitems.filters
@@ -17,6 +17,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ModelImporter_GLTF.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ModelImporter_OBJ.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)NameWindow.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)NodeEditorWindow.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ObjectWindow.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)PaintToolWindow.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)GraphicsWindow.cpp" />
@@ -73,6 +74,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)MeshWindow.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ModelImporter.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)NameWindow.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)NodeEditorWindow.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ObjectWindow.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PaintToolWindow.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)GraphicsWindow.h" />

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -2,7 +2,6 @@
 #include "stdafx.h"
 #include "NodeEditorWindow.h"
 #include "wiImage.h"
-#include "wiRenderer.h"
 // clang-format on
 
 using namespace wi::graphics;
@@ -46,13 +45,22 @@ void NodeEditorWindow::Render(const wi::Canvas &canvas, CommandList cmd) const {
     for (size_t i = 1; i < nodes.size(); ++i) {
       const auto &a = nodes[i - 1]->window;
       const auto &b = nodes[i]->window;
-      wi::renderer::RenderableLine2D line;
-      line.start = XMFLOAT2(a.translation.x + a.scale.x * 0.5f,
-                            a.translation.y + a.scale.y * 0.5f);
-      line.end = XMFLOAT2(b.translation.x + b.scale.x * 0.5f,
-                          b.translation.y + b.scale.y * 0.5f);
-      line.color_start = line.color_end = XMFLOAT4(1, 1, 1, 1);
-      wi::renderer::DrawLine(line);
+      XMFLOAT2 a_center(a.translation.x + a.scale.x * 0.5f,
+                        a.translation.y + a.scale.y * 0.5f);
+      XMFLOAT2 b_center(b.translation.x + b.scale.x * 0.5f,
+                        b.translation.y + b.scale.y * 0.5f);
+      float length = wi::math::Distance(a_center, b_center);
+      float angle =
+          std::atan2(b_center.y - a_center.y, b_center.x - a_center.x);
+      XMFLOAT2 mid((a_center.x + b_center.x) * 0.5f,
+                   (a_center.y + b_center.y) * 0.5f);
+      wi::image::Params lineParams;
+      lineParams.pos = XMFLOAT3(mid.x, mid.y, 0);
+      lineParams.siz = XMFLOAT2(length, 2);
+      lineParams.pivot = XMFLOAT2(0.5f, 0.5f);
+      lineParams.rotation = angle;
+      lineParams.color = XMFLOAT4(1, 1, 1, 1);
+      wi::image::Draw(nullptr, lineParams, cmd);
     }
   }
 }

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -8,21 +8,21 @@ using namespace wi::gui;
 
 void NodeEditorWindow::Create(EditorComponent* _editor)
 {
-	editor = _editor;
-	wi::gui::Window::Create("Node Editor");
-	SetSize(XMFLOAT2(800, 600));
-	SetMinimized(true);
-	SetVisible(false);
+        editor = _editor;
+        control_size = 30;
+        wi::gui::Window::Create("Node Editor");
+        RemoveWidget(&scrollbar_horizontal);
+        SetVisible(false);
 
-	addNodeButton.Create("Add Node");
-	addNodeButton.SetPos(XMFLOAT2(4, 4));
-	addNodeButton.SetSize(XMFLOAT2(100, 20));
-	addNodeButton.SetTooltip("Create a new node");
-	addNodeButton.OnClick([this](wi::gui::EventArgs args) {
-		XMFLOAT2 pos = XMFLOAT2(50 + nodes.size() * 120.0f, 80.0f);
-		AddNode("Node " + std::to_string(nodes.size()), pos);
-	});
-	AddWidget(&addNodeButton);
+        addNodeButton.Create("Add Node");
+        addNodeButton.SetTooltip("Create a new node");
+        addNodeButton.SetLocalizationEnabled(false);
+        addNodeButton.SetSize(XMFLOAT2(100, 20));
+        addNodeButton.OnClick([this](wi::gui::EventArgs args) {
+                XMFLOAT2 pos = XMFLOAT2(50 + nodes.size() * 120.0f, 80.0f);
+                AddNode("Node " + std::to_string(nodes.size()), pos);
+        });
+        AddWidget(&addNodeButton, wi::gui::Window::AttachmentOptions::NONE);
 }
 
 void NodeEditorWindow::AddNode(const std::string& name, const XMFLOAT2& position)
@@ -45,7 +45,40 @@ void NodeEditorWindow::AddNode(const std::string& name, const XMFLOAT2& position
 
 void NodeEditorWindow::Update(const wi::Canvas& canvas, float dt)
 {
-	wi::gui::Window::Update(canvas, dt);
+        wi::gui::Window::Update(canvas, dt);
+
+        SetShadowRadius(6);
+
+        static const float radius = 15;
+        for (int i = 0; i < arraysize(wi::gui::Widget::sprites); ++i)
+        {
+                sprites[i].params.enableCornerRounding();
+                sprites[i].params.corners_rounding[0].radius = radius;
+                sprites[i].params.corners_rounding[1].radius = radius;
+                sprites[i].params.corners_rounding[2].radius = radius;
+                sprites[i].params.corners_rounding[3].radius = radius;
+
+                addNodeButton.sprites[i].params.enableCornerRounding();
+                addNodeButton.sprites[i].params.corners_rounding[0].radius = radius;
+                addNodeButton.sprites[i].params.corners_rounding[1].radius = radius;
+                addNodeButton.sprites[i].params.corners_rounding[2].radius = radius;
+                addNodeButton.sprites[i].params.corners_rounding[3].radius = radius;
+        }
+
+        addNodeButton.SetShadowRadius(0);
+
+        for (auto& node : nodes)
+        {
+                node->window.SetShadowRadius(4);
+                for (auto& spr : node->window.sprites)
+                {
+                        spr.params.enableCornerRounding();
+                        spr.params.corners_rounding[0].radius = radius;
+                        spr.params.corners_rounding[1].radius = radius;
+                        spr.params.corners_rounding[2].radius = radius;
+                        spr.params.corners_rounding[3].radius = radius;
+                }
+        }
 }
 
 void NodeEditorWindow::Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const
@@ -78,7 +111,11 @@ void NodeEditorWindow::Render(const wi::Canvas& canvas, wi::graphics::CommandLis
 
 void NodeEditorWindow::ResizeLayout()
 {
-	wi::gui::Window::ResizeLayout();
-	addNodeButton.SetPos(XMFLOAT2(4, 4));
+        wi::gui::Window::ResizeLayout();
+        const float padding = 4;
+
+        addNodeButton.Detach();
+        addNodeButton.SetPos(XMFLOAT2(translation.x + padding, translation.y + scale.y - addNodeButton.GetSize().y - padding));
+        addNodeButton.AttachTo(this);
 }
 

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -1,121 +1,118 @@
-#include "stdafx.h"
 #include "NodeEditorWindow.h"
 #include "Editor.h"
+#include "stdafx.h"
 #include "wiRenderer.h"
 
 using namespace wi::graphics;
 using namespace wi::gui;
 
-void NodeEditorWindow::Create(EditorComponent* _editor)
-{
-        editor = _editor;
-        control_size = 30;
-        wi::gui::Window::Create("Node Editor");
-        RemoveWidget(&scrollbar_horizontal);
-        SetVisible(false);
+void NodeEditorWindow::Create(EditorComponent *_editor) {
+  editor = _editor;
+  control_size = 30;
+  wi::gui::Window::Create("Node Editor");
+  RemoveWidget(&scrollbar_horizontal);
+  RemoveWidget(&scrollbar_vertical);
+  SetVisible(false);
 
-        addNodeButton.Create("Add Node");
-        addNodeButton.SetTooltip("Create a new node");
-        addNodeButton.SetLocalizationEnabled(false);
-        addNodeButton.SetSize(XMFLOAT2(100, 20));
-        addNodeButton.OnClick([this](wi::gui::EventArgs args) {
-                XMFLOAT2 pos = XMFLOAT2(50 + nodes.size() * 120.0f, 80.0f);
-                AddNode("Node " + std::to_string(nodes.size()), pos);
-        });
-        AddWidget(&addNodeButton, wi::gui::Window::AttachmentOptions::NONE);
+  addNodeButton.Create("Add Node");
+  addNodeButton.SetTooltip("Create a new node");
+  addNodeButton.SetLocalizationEnabled(false);
+  addNodeButton.SetSize(XMFLOAT2(100, 20));
+  addNodeButton.OnClick([this](wi::gui::EventArgs args) {
+    XMFLOAT2 pos = XMFLOAT2(50 + nodes.size() * 120.0f, 80.0f);
+    AddNode("Node " + std::to_string(nodes.size()), pos);
+  });
+  AddWidget(&addNodeButton, wi::gui::Window::AttachmentOptions::NONE);
 }
 
-void NodeEditorWindow::AddNode(const std::string& name, const XMFLOAT2& position)
-{
-        nodes.emplace_back(std::make_unique<Node>());
-        Node& node = *nodes.back();
-        node.window.Create(name, Window::WindowControls::MOVE | Window::WindowControls::DISABLE_TITLE_BAR);
-        node.window.SetSize(XMFLOAT2(120, 60));
-        node.window.SetPos(position);
-        node.window.SetVisible(true);
-        node.window.SetColor(wi::Color(60, 60, 60, 200));
+void NodeEditorWindow::AddNode(const std::string &name,
+                               const XMFLOAT2 &position) {
+  nodes.emplace_back(std::make_unique<Node>());
+  Node &node = *nodes.back();
+  node.window.Create(name, Window::WindowControls::MOVE |
+                               Window::WindowControls::DISABLE_TITLE_BAR);
+  node.window.SetSize(XMFLOAT2(120, 60));
+  node.window.SetPos(position);
+  node.window.SetVisible(true);
+  node.window.SetColor(wi::Color(60, 60, 60, 200));
 
-        AddWidget(&node.window);
+  AddWidget(&node.window, wi::gui::Window::AttachmentOptions::NONE);
 
-	if (nodes.size() > 1)
-	{
-		links.emplace_back(nodes.size() - 2, nodes.size() - 1);
-	}
+  if (nodes.size() > 1) {
+    links.emplace_back(nodes.size() - 2, nodes.size() - 1);
+  }
 }
 
-void NodeEditorWindow::Update(const wi::Canvas& canvas, float dt)
-{
-        wi::gui::Window::Update(canvas, dt);
+void NodeEditorWindow::Update(const wi::Canvas &canvas, float dt) {
+  wi::gui::Window::Update(canvas, dt);
 
-        SetShadowRadius(6);
+  SetShadowRadius(6);
 
-        static const float radius = 15;
-        for (int i = 0; i < arraysize(wi::gui::Widget::sprites); ++i)
-        {
-                sprites[i].params.enableCornerRounding();
-                sprites[i].params.corners_rounding[0].radius = radius;
-                sprites[i].params.corners_rounding[1].radius = radius;
-                sprites[i].params.corners_rounding[2].radius = radius;
-                sprites[i].params.corners_rounding[3].radius = radius;
+  static const float radius = 15;
+  for (int i = 0; i < arraysize(wi::gui::Widget::sprites); ++i) {
+    sprites[i].params.enableCornerRounding();
+    sprites[i].params.corners_rounding[0].radius = radius;
+    sprites[i].params.corners_rounding[1].radius = radius;
+    sprites[i].params.corners_rounding[2].radius = radius;
+    sprites[i].params.corners_rounding[3].radius = radius;
 
-                addNodeButton.sprites[i].params.enableCornerRounding();
-                addNodeButton.sprites[i].params.corners_rounding[0].radius = radius;
-                addNodeButton.sprites[i].params.corners_rounding[1].radius = radius;
-                addNodeButton.sprites[i].params.corners_rounding[2].radius = radius;
-                addNodeButton.sprites[i].params.corners_rounding[3].radius = radius;
-        }
+    addNodeButton.sprites[i].params.enableCornerRounding();
+    addNodeButton.sprites[i].params.corners_rounding[0].radius = radius;
+    addNodeButton.sprites[i].params.corners_rounding[1].radius = radius;
+    addNodeButton.sprites[i].params.corners_rounding[2].radius = radius;
+    addNodeButton.sprites[i].params.corners_rounding[3].radius = radius;
+  }
 
-        addNodeButton.SetShadowRadius(0);
+  addNodeButton.SetShadowRadius(0);
 
-        for (auto& node : nodes)
-        {
-                node->window.SetShadowRadius(4);
-                for (auto& spr : node->window.sprites)
-                {
-                        spr.params.enableCornerRounding();
-                        spr.params.corners_rounding[0].radius = radius;
-                        spr.params.corners_rounding[1].radius = radius;
-                        spr.params.corners_rounding[2].radius = radius;
-                        spr.params.corners_rounding[3].radius = radius;
-                }
-        }
+  for (auto &node : nodes) {
+    node->window.SetShadowRadius(4);
+    for (auto &spr : node->window.sprites) {
+      spr.params.enableCornerRounding();
+      spr.params.corners_rounding[0].radius = radius;
+      spr.params.corners_rounding[1].radius = radius;
+      spr.params.corners_rounding[2].radius = radius;
+      spr.params.corners_rounding[3].radius = radius;
+    }
+  }
 }
 
-void NodeEditorWindow::Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const
-{
-	wi::gui::Window::Render(canvas, cmd);
+void NodeEditorWindow::Render(const wi::Canvas &canvas,
+                              wi::graphics::CommandList cmd) const {
+  wi::gui::Window::Render(canvas, cmd);
 
-	if (!IsVisible())
-		return;
+  if (!IsVisible())
+    return;
 
-	wi::gui::Window::ApplyScissor(canvas, scissorRect, cmd);
+  wi::gui::Window::ApplyScissor(canvas, scissorRect, cmd);
 
-	for (auto& link : links)
-	{
-		if (link.first >= nodes.size() || link.second >= nodes.size())
-			continue;
+  for (auto &link : links) {
+    if (link.first >= nodes.size() || link.second >= nodes.size())
+      continue;
 
-                const Node& a = *nodes[link.first];
-                const Node& b = *nodes[link.second];
+    const Node &a = *nodes[link.first];
+    const Node &b = *nodes[link.second];
 
-		wi::renderer::RenderableLine2D line;
-                line.start = XMFLOAT2(a.window.GetPos().x + a.window.GetSize().x * 0.5f,
-                                                          a.window.GetPos().y + a.window.GetSize().y * 0.5f);
-                line.end = XMFLOAT2(b.window.GetPos().x + b.window.GetSize().x * 0.5f,
-                                                        b.window.GetPos().y + b.window.GetSize().y * 0.5f);
-                line.color_start = wi::Color::White();
-                line.color_end = wi::Color::White();
-                wi::renderer::DrawLine(line);
-	}
+    wi::renderer::RenderableLine2D line;
+    line.start = XMFLOAT2(a.window.GetPos().x + a.window.GetSize().x * 0.5f,
+                          a.window.GetPos().y + a.window.GetSize().y * 0.5f);
+    line.end = XMFLOAT2(b.window.GetPos().x + b.window.GetSize().x * 0.5f,
+                        b.window.GetPos().y + b.window.GetSize().y * 0.5f);
+    line.color_start = wi::Color::White();
+    line.color_end = wi::Color::White();
+    wi::renderer::DrawLine(line);
+  }
 }
 
-void NodeEditorWindow::ResizeLayout()
-{
-        wi::gui::Window::ResizeLayout();
-        const float padding = 4;
+void NodeEditorWindow::ResizeLayout() {
+  wi::gui::Window::ResizeLayout();
+  const float padding = 4;
 
-        addNodeButton.Detach();
-        addNodeButton.SetPos(XMFLOAT2(translation.x + padding, translation.y + scale.y - addNodeButton.GetSize().y - padding));
-        addNodeButton.AttachTo(this);
+  addNodeButton.Detach();
+  addNodeButton.SetSize(
+      XMFLOAT2(GetWidgetAreaSize().x - padding * 2, addNodeButton.GetSize().y));
+  addNodeButton.SetPos(
+      XMFLOAT2(translation.x + padding,
+               translation.y + scale.y - addNodeButton.GetSize().y - padding));
+  addNodeButton.AttachTo(this);
 }
-

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -117,19 +117,21 @@ void NodeEditorWindow::ResizeLayout() {
   const float sep = translation.x + separator + 10;
   float hoffset = sep;
   for (auto &node : nodes) {
+    node->window.Detach();
     node->window.SetPos(XMFLOAT2(hoffset, y));
     hoffset += node->window.GetSize().x + 15;
     if (hoffset + node->window.GetSize().x >= translation.x + width) {
       hoffset = sep;
       y += node->window.GetSize().y + 40;
     }
+    node->window.AttachTo(this);
   }
 }
 
 void NodeEditorWindow::AddNode() {
   std::string name = "Node " + std::to_string(nodes.size() + 1);
   auto node = std::make_unique<Node>(name);
-  node->window.Create("", Window::WindowControls::MOVE |
+  node->window.Create(name, Window::WindowControls::MOVE |
                               Window::WindowControls::DISABLE_TITLE_BAR);
   node->window.SetSize(XMFLOAT2(120, 60));
 
@@ -139,7 +141,7 @@ void NodeEditorWindow::AddNode() {
   node->label.SetSize(XMFLOAT2(112, 20));
   node->window.AddWidget(&node->label);
 
-  AddWidget(&node->window, wi::gui::Window::AttachmentOptions::NONE);
+  node->window.AttachTo(this);
   nodes.push_back(std::move(node));
   ResizeLayout();
 }

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -1,8 +1,8 @@
-#include "NodeEditorWindow.h"
-#include "Editor.h"
+// clang-format off
 #include "stdafx.h"
+#include "NodeEditorWindow.h"
 #include "wiImage.h"
-#include "wiRenderer.h"
+// clang-format on
 
 using namespace wi::graphics;
 using namespace wi::gui;
@@ -12,37 +12,25 @@ static const float separator = 140.0f;
 void NodeEditorWindow::Create(EditorComponent *_editor) {
   editor = _editor;
   control_size = 30;
-  wi::gui::Window::Create("Node Editor");
-  RemoveWidget(&scrollbar_horizontal);
-  RemoveWidget(&scrollbar_vertical);
-  SetVisible(false);
 
-  addNodeButton.Create("Add Node");
-  addNodeButton.SetTooltip("Create a new node");
-  addNodeButton.SetLocalizationEnabled(false);
-  addNodeButton.SetSize(XMFLOAT2(100, 20));
-  addNodeButton.OnClick([this](wi::gui::EventArgs args) {
-    XMFLOAT2 pos = XMFLOAT2(separator + 20 + nodes.size() * 120.0f, 80.0f);
-    AddNode("Node " + std::to_string(nodes.size()), pos);
-  });
-  AddWidget(&addNodeButton, wi::gui::Window::AttachmentOptions::NONE);
+  wi::gui::Window::Create("Node Editor");
+
+  RemoveWidget(&scrollbar_horizontal);
+
+  SetVisible(false);
 }
 
-void NodeEditorWindow::AddNode(const std::string &name,
-                               const XMFLOAT2 &position) {
-  nodes.emplace_back(std::make_unique<Node>());
-  Node &node = *nodes.back();
-  node.window.Create(name, Window::WindowControls::MOVE |
-                               Window::WindowControls::DISABLE_TITLE_BAR);
-  node.window.SetSize(XMFLOAT2(120, 60));
-  node.window.SetPos(position);
-  node.window.SetVisible(true);
-  node.window.SetColor(wi::Color(60, 60, 60, 200));
+void NodeEditorWindow::Render(const wi::Canvas &canvas, CommandList cmd) const {
+  wi::gui::Window::Render(canvas, cmd);
 
-  AddWidget(&node.window, wi::gui::Window::AttachmentOptions::NONE);
-
-  if (nodes.size() > 1) {
-    links.emplace_back(nodes.size() - 2, nodes.size() - 1);
+  if (IsVisible() && !IsCollapsed()) {
+    ApplyScissor(canvas, scissorRect, cmd);
+    wi::image::Params params;
+    params.pos =
+        XMFLOAT3(translation.x + separator, translation.y + control_size, 0);
+    params.siz = XMFLOAT2(2, scale.y - control_size);
+    params.color = shadow_color;
+    wi::image::Draw(nullptr, params, cmd);
   }
 }
 
@@ -52,77 +40,14 @@ void NodeEditorWindow::Update(const wi::Canvas &canvas, float dt) {
   SetShadowRadius(6);
 
   static const float radius = 15;
+
   for (int i = 0; i < arraysize(wi::gui::Widget::sprites); ++i) {
     sprites[i].params.enableCornerRounding();
     sprites[i].params.corners_rounding[0].radius = radius;
     sprites[i].params.corners_rounding[1].radius = radius;
     sprites[i].params.corners_rounding[2].radius = radius;
     sprites[i].params.corners_rounding[3].radius = radius;
-
-    addNodeButton.sprites[i].params.enableCornerRounding();
-    addNodeButton.sprites[i].params.corners_rounding[0].radius = radius;
-    addNodeButton.sprites[i].params.corners_rounding[1].radius = radius;
-    addNodeButton.sprites[i].params.corners_rounding[2].radius = radius;
-    addNodeButton.sprites[i].params.corners_rounding[3].radius = radius;
-  }
-
-  addNodeButton.SetShadowRadius(0);
-
-  for (auto &node : nodes) {
-    node->window.SetShadowRadius(4);
-    for (auto &spr : node->window.sprites) {
-      spr.params.enableCornerRounding();
-      spr.params.corners_rounding[0].radius = radius;
-      spr.params.corners_rounding[1].radius = radius;
-      spr.params.corners_rounding[2].radius = radius;
-      spr.params.corners_rounding[3].radius = radius;
-    }
   }
 }
 
-void NodeEditorWindow::Render(const wi::Canvas &canvas,
-                              wi::graphics::CommandList cmd) const {
-  wi::gui::Window::Render(canvas, cmd);
-
-  if (!IsVisible())
-    return;
-
-  wi::gui::Window::ApplyScissor(canvas, scissorRect, cmd);
-
-  // draw separator similar to Content Browser
-  wi::image::Params params;
-  params.pos =
-      XMFLOAT3(translation.x + separator, translation.y + control_size, 0);
-  params.siz = XMFLOAT2(2, scale.y - control_size);
-  params.color = shadow_color;
-  wi::image::Draw(nullptr, params, cmd);
-
-  for (auto &link : links) {
-    if (link.first >= nodes.size() || link.second >= nodes.size())
-      continue;
-
-    const Node &a = *nodes[link.first];
-    const Node &b = *nodes[link.second];
-
-    wi::renderer::RenderableLine2D line;
-    line.start = XMFLOAT2(a.window.GetPos().x + a.window.GetSize().x * 0.5f,
-                          a.window.GetPos().y + a.window.GetSize().y * 0.5f);
-    line.end = XMFLOAT2(b.window.GetPos().x + b.window.GetSize().x * 0.5f,
-                        b.window.GetPos().y + b.window.GetSize().y * 0.5f);
-    line.color_start = wi::Color::White();
-    line.color_end = wi::Color::White();
-    wi::renderer::DrawLine(line);
-  }
-}
-
-void NodeEditorWindow::ResizeLayout() {
-  wi::gui::Window::ResizeLayout();
-  const float padding = 4;
-
-  addNodeButton.Detach();
-  addNodeButton.SetPos(XMFLOAT2(translation.x + padding,
-                                translation.y + control_size + padding));
-  addNodeButton.SetSize(
-      XMFLOAT2(separator - padding * 2, addNodeButton.GetSize().y));
-  addNodeButton.AttachTo(this);
-}
+void NodeEditorWindow::ResizeLayout() { wi::gui::Window::ResizeLayout(); }

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -17,6 +17,11 @@ void NodeEditorWindow::Create(EditorComponent *_editor) {
 
   RemoveWidget(&scrollbar_horizontal);
 
+  addNodeButton.Create("Add Node");
+  addNodeButton.SetLocalizationEnabled(false);
+  addNodeButton.SetSize(XMFLOAT2(120, 25));
+  AddWidget(&addNodeButton, wi::gui::Window::AttachmentOptions::NONE);
+
   SetVisible(false);
 }
 
@@ -47,7 +52,26 @@ void NodeEditorWindow::Update(const wi::Canvas &canvas, float dt) {
     sprites[i].params.corners_rounding[1].radius = radius;
     sprites[i].params.corners_rounding[2].radius = radius;
     sprites[i].params.corners_rounding[3].radius = radius;
+
+    addNodeButton.sprites[i].params.enableCornerRounding();
+    addNodeButton.sprites[i].params.corners_rounding[0].radius = radius;
+    addNodeButton.sprites[i].params.corners_rounding[1].radius = radius;
+    addNodeButton.sprites[i].params.corners_rounding[2].radius = radius;
+    addNodeButton.sprites[i].params.corners_rounding[3].radius = radius;
   }
+
+  addNodeButton.SetShadowRadius(0);
 }
 
-void NodeEditorWindow::ResizeLayout() { wi::gui::Window::ResizeLayout(); }
+void NodeEditorWindow::ResizeLayout() {
+  wi::gui::Window::ResizeLayout();
+  const float padding = 4;
+
+  addNodeButton.Detach();
+  addNodeButton.SetPos(
+      XMFLOAT2(translation.x + padding,
+               translation.y + scale.y - addNodeButton.GetSize().y - padding));
+  addNodeButton.SetSize(
+      XMFLOAT2(separator - padding * 2, addNodeButton.GetSize().y));
+  addNodeButton.AttachTo(this);
+}

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -111,23 +111,37 @@ void NodeEditorWindow::ResizeLayout() {
   addNodeButton.SetSize(
       XMFLOAT2(separator - padding * 2, addNodeButton.GetSize().y));
   addNodeButton.AttachTo(this);
+
+  const float width = GetWidgetAreaSize().x;
+  float y = translation.y + control_size + padding + 10;
+  const float sep = translation.x + separator + 10;
+  float hoffset = sep;
+  for (auto &node : nodes) {
+    node->window.Detach();
+    node->window.SetPos(XMFLOAT2(hoffset, y));
+    hoffset += node->window.GetSize().x + 15;
+    if (hoffset + node->window.GetSize().x >= translation.x + width) {
+      hoffset = sep;
+      y += node->window.GetSize().y + 40;
+    }
+    node->window.AttachTo(this);
+  }
 }
 
 void NodeEditorWindow::AddNode() {
-  auto node = std::make_unique<Node>();
-  node->window.Create("");
-  node->window.SetControls(wi::gui::WindowControls::MOVE |
-                           wi::gui::WindowControls::DISABLE_TITLE_BAR);
+  std::string name = "Node " + std::to_string(nodes.size() + 1);
+  auto node = std::make_unique<Node>(name);
+  node->window.Create("", Window::WindowControls::MOVE |
+                              Window::WindowControls::DISABLE_TITLE_BAR);
   node->window.SetSize(XMFLOAT2(120, 60));
 
-  XMFLOAT2 pos(translation.x + separator + 20,
-               translation.y + control_size + 20);
-  if (!nodes.empty()) {
-    const auto &prev = nodes.back()->window;
-    pos.x = prev.translation.x + 40.0f;
-    pos.y = prev.translation.y + prev.scale.y + 20.0f;
-  }
-  node->window.SetPos(pos);
+  node->label.Create(name);
+  node->label.SetText(name);
+  node->label.SetPos(XMFLOAT2(4, 4));
+  node->label.SetSize(XMFLOAT2(112, 20));
+  node->window.AddWidget(&node->label);
+
   node->window.AttachTo(this);
   nodes.push_back(std::move(node));
+  ResizeLayout();
 }

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "NodeEditorWindow.h"
 #include "wiImage.h"
+#include "wiRenderer.h"
 // clang-format on
 
 using namespace wi::graphics;
@@ -16,10 +17,15 @@ void NodeEditorWindow::Create(EditorComponent *_editor) {
   wi::gui::Window::Create("Node Editor");
 
   RemoveWidget(&scrollbar_horizontal);
+  RemoveWidget(&scrollbar_vertical);
+  scrollable_area.Detach();
+  scrollable_area.SetEnabled(false);
+  scrollable_area.SetVisible(false);
 
   addNodeButton.Create("Add Node");
   addNodeButton.SetLocalizationEnabled(false);
   addNodeButton.SetSize(XMFLOAT2(120, 25));
+  addNodeButton.OnClick([this](wi::gui::EventArgs) { AddNode(); });
   AddWidget(&addNodeButton, wi::gui::Window::AttachmentOptions::NONE);
 
   SetVisible(false);
@@ -36,6 +42,18 @@ void NodeEditorWindow::Render(const wi::Canvas &canvas, CommandList cmd) const {
     params.siz = XMFLOAT2(2, scale.y - control_size);
     params.color = shadow_color;
     wi::image::Draw(nullptr, params, cmd);
+
+    for (size_t i = 1; i < nodes.size(); ++i) {
+      const auto &a = nodes[i - 1]->window;
+      const auto &b = nodes[i]->window;
+      wi::renderer::RenderableLine2D line;
+      line.start = XMFLOAT2(a.translation.x + a.scale.x * 0.5f,
+                            a.translation.y + a.scale.y * 0.5f);
+      line.end = XMFLOAT2(b.translation.x + b.scale.x * 0.5f,
+                          b.translation.y + b.scale.y * 0.5f);
+      line.color_start = line.color_end = XMFLOAT4(1, 1, 1, 1);
+      wi::renderer::DrawLine(line);
+    }
   }
 }
 
@@ -60,6 +78,17 @@ void NodeEditorWindow::Update(const wi::Canvas &canvas, float dt) {
     addNodeButton.sprites[i].params.corners_rounding[3].radius = radius;
   }
 
+  for (auto &node : nodes) {
+    node->window.SetShadowRadius(2);
+    for (int i = 0; i < arraysize(wi::gui::Widget::sprites); ++i) {
+      node->window.sprites[i].params.enableCornerRounding();
+      node->window.sprites[i].params.corners_rounding[0].radius = radius;
+      node->window.sprites[i].params.corners_rounding[1].radius = radius;
+      node->window.sprites[i].params.corners_rounding[2].radius = radius;
+      node->window.sprites[i].params.corners_rounding[3].radius = radius;
+    }
+  }
+
   addNodeButton.SetShadowRadius(0);
 }
 
@@ -74,4 +103,23 @@ void NodeEditorWindow::ResizeLayout() {
   addNodeButton.SetSize(
       XMFLOAT2(separator - padding * 2, addNodeButton.GetSize().y));
   addNodeButton.AttachTo(this);
+}
+
+void NodeEditorWindow::AddNode() {
+  auto node = std::make_unique<Node>();
+  node->window.Create("");
+  node->window.SetControls(wi::gui::WindowControls::MOVE |
+                           wi::gui::WindowControls::DISABLE_TITLE_BAR);
+  node->window.SetSize(XMFLOAT2(120, 60));
+
+  XMFLOAT2 pos(translation.x + separator + 20,
+               translation.y + control_size + 20);
+  if (!nodes.empty()) {
+    const auto &prev = nodes.back()->window;
+    pos.x = prev.translation.x + 40.0f;
+    pos.y = prev.translation.y + prev.scale.y + 20.0f;
+  }
+  node->window.SetPos(pos);
+  node->window.AttachTo(this);
+  nodes.push_back(std::move(node));
 }

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -27,16 +27,15 @@ void NodeEditorWindow::Create(EditorComponent* _editor)
 
 void NodeEditorWindow::AddNode(const std::string& name, const XMFLOAT2& position)
 {
-	nodes.emplace_back();
-	Node& node = nodes.back();
-	node.window.Create(name);
-	node.window.SetSize(XMFLOAT2(120, 60));
-	node.window.SetPos(position);
-	node.window.SetMovable(true);
-	node.window.SetVisible(true);
-	node.window.SetColor(wi::Color(60, 60, 60, 200));
+        nodes.emplace_back(std::make_unique<Node>());
+        Node& node = *nodes.back();
+        node.window.Create(name, Window::WindowControls::MOVE | Window::WindowControls::DISABLE_TITLE_BAR);
+        node.window.SetSize(XMFLOAT2(120, 60));
+        node.window.SetPos(position);
+        node.window.SetVisible(true);
+        node.window.SetColor(wi::Color(60, 60, 60, 200));
 
-	AddWidget(&node.window);
+        AddWidget(&node.window);
 
 	if (nodes.size() > 1)
 	{
@@ -63,16 +62,17 @@ void NodeEditorWindow::Render(const wi::Canvas& canvas, wi::graphics::CommandLis
 		if (link.first >= nodes.size() || link.second >= nodes.size())
 			continue;
 
-		const Node& a = nodes[link.first];
-		const Node& b = nodes[link.second];
+                const Node& a = *nodes[link.first];
+                const Node& b = *nodes[link.second];
 
 		wi::renderer::RenderableLine2D line;
-		line.start = XMFLOAT2(a.window.GetPos().x + a.window.GetSize().x * 0.5f,
-							  a.window.GetPos().y + a.window.GetSize().y * 0.5f);
-		line.end = XMFLOAT2(b.window.GetPos().x + b.window.GetSize().x * 0.5f,
-							b.window.GetPos().y + b.window.GetSize().y * 0.5f);
-		line.color = wi::Color::White();
-		wi::renderer::DrawLine(line);
+                line.start = XMFLOAT2(a.window.GetPos().x + a.window.GetSize().x * 0.5f,
+                                                          a.window.GetPos().y + a.window.GetSize().y * 0.5f);
+                line.end = XMFLOAT2(b.window.GetPos().x + b.window.GetSize().x * 0.5f,
+                                                        b.window.GetPos().y + b.window.GetSize().y * 0.5f);
+                line.color_start = wi::Color::White();
+                line.color_end = wi::Color::White();
+                wi::renderer::DrawLine(line);
 	}
 }
 

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -1,0 +1,84 @@
+#include "stdafx.h"
+#include "NodeEditorWindow.h"
+#include "Editor.h"
+#include "wiRenderer.h"
+
+using namespace wi::graphics;
+using namespace wi::gui;
+
+void NodeEditorWindow::Create(EditorComponent* _editor)
+{
+	editor = _editor;
+	wi::gui::Window::Create("Node Editor");
+	SetSize(XMFLOAT2(800, 600));
+	SetMinimized(true);
+	SetVisible(false);
+
+	addNodeButton.Create("Add Node");
+	addNodeButton.SetPos(XMFLOAT2(4, 4));
+	addNodeButton.SetSize(XMFLOAT2(100, 20));
+	addNodeButton.SetTooltip("Create a new node");
+	addNodeButton.OnClick([this](wi::gui::EventArgs args) {
+		XMFLOAT2 pos = XMFLOAT2(50 + nodes.size() * 120.0f, 80.0f);
+		AddNode("Node " + std::to_string(nodes.size()), pos);
+	});
+	AddWidget(&addNodeButton);
+}
+
+void NodeEditorWindow::AddNode(const std::string& name, const XMFLOAT2& position)
+{
+	nodes.emplace_back();
+	Node& node = nodes.back();
+	node.window.Create(name);
+	node.window.SetSize(XMFLOAT2(120, 60));
+	node.window.SetPos(position);
+	node.window.SetMovable(true);
+	node.window.SetVisible(true);
+	node.window.SetColor(wi::Color(60, 60, 60, 200));
+
+	AddWidget(&node.window);
+
+	if (nodes.size() > 1)
+	{
+		links.emplace_back(nodes.size() - 2, nodes.size() - 1);
+	}
+}
+
+void NodeEditorWindow::Update(const wi::Canvas& canvas, float dt)
+{
+	wi::gui::Window::Update(canvas, dt);
+}
+
+void NodeEditorWindow::Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const
+{
+	wi::gui::Window::Render(canvas, cmd);
+
+	if (!IsVisible())
+		return;
+
+	wi::gui::Window::ApplyScissor(canvas, scissorRect, cmd);
+
+	for (auto& link : links)
+	{
+		if (link.first >= nodes.size() || link.second >= nodes.size())
+			continue;
+
+		const Node& a = nodes[link.first];
+		const Node& b = nodes[link.second];
+
+		wi::renderer::RenderableLine2D line;
+		line.start = XMFLOAT2(a.window.GetPos().x + a.window.GetSize().x * 0.5f,
+							  a.window.GetPos().y + a.window.GetSize().y * 0.5f);
+		line.end = XMFLOAT2(b.window.GetPos().x + b.window.GetSize().x * 0.5f,
+							b.window.GetPos().y + b.window.GetSize().y * 0.5f);
+		line.color = wi::Color::White();
+		wi::renderer::DrawLine(line);
+	}
+}
+
+void NodeEditorWindow::ResizeLayout()
+{
+	wi::gui::Window::ResizeLayout();
+	addNodeButton.SetPos(XMFLOAT2(4, 4));
+}
+

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -117,14 +117,12 @@ void NodeEditorWindow::ResizeLayout() {
   const float sep = translation.x + separator + 10;
   float hoffset = sep;
   for (auto &node : nodes) {
-    node->window.Detach();
     node->window.SetPos(XMFLOAT2(hoffset, y));
     hoffset += node->window.GetSize().x + 15;
     if (hoffset + node->window.GetSize().x >= translation.x + width) {
       hoffset = sep;
       y += node->window.GetSize().y + 40;
     }
-    node->window.AttachTo(this);
   }
 }
 
@@ -141,7 +139,7 @@ void NodeEditorWindow::AddNode() {
   node->label.SetSize(XMFLOAT2(112, 20));
   node->window.AddWidget(&node->label);
 
-  node->window.AttachTo(this);
+  AddWidget(&node->window, wi::gui::Window::AttachmentOptions::NONE);
   nodes.push_back(std::move(node));
   ResizeLayout();
 }

--- a/Editor/NodeEditorWindow.cpp
+++ b/Editor/NodeEditorWindow.cpp
@@ -1,10 +1,13 @@
 #include "NodeEditorWindow.h"
 #include "Editor.h"
 #include "stdafx.h"
+#include "wiImage.h"
 #include "wiRenderer.h"
 
 using namespace wi::graphics;
 using namespace wi::gui;
+
+static const float separator = 140.0f;
 
 void NodeEditorWindow::Create(EditorComponent *_editor) {
   editor = _editor;
@@ -19,7 +22,7 @@ void NodeEditorWindow::Create(EditorComponent *_editor) {
   addNodeButton.SetLocalizationEnabled(false);
   addNodeButton.SetSize(XMFLOAT2(100, 20));
   addNodeButton.OnClick([this](wi::gui::EventArgs args) {
-    XMFLOAT2 pos = XMFLOAT2(50 + nodes.size() * 120.0f, 80.0f);
+    XMFLOAT2 pos = XMFLOAT2(separator + 20 + nodes.size() * 120.0f, 80.0f);
     AddNode("Node " + std::to_string(nodes.size()), pos);
   });
   AddWidget(&addNodeButton, wi::gui::Window::AttachmentOptions::NONE);
@@ -86,6 +89,14 @@ void NodeEditorWindow::Render(const wi::Canvas &canvas,
 
   wi::gui::Window::ApplyScissor(canvas, scissorRect, cmd);
 
+  // draw separator similar to Content Browser
+  wi::image::Params params;
+  params.pos =
+      XMFLOAT3(translation.x + separator, translation.y + control_size, 0);
+  params.siz = XMFLOAT2(2, scale.y - control_size);
+  params.color = shadow_color;
+  wi::image::Draw(nullptr, params, cmd);
+
   for (auto &link : links) {
     if (link.first >= nodes.size() || link.second >= nodes.size())
       continue;
@@ -109,10 +120,9 @@ void NodeEditorWindow::ResizeLayout() {
   const float padding = 4;
 
   addNodeButton.Detach();
+  addNodeButton.SetPos(XMFLOAT2(translation.x + padding,
+                                translation.y + control_size + padding));
   addNodeButton.SetSize(
-      XMFLOAT2(GetWidgetAreaSize().x - padding * 2, addNodeButton.GetSize().y));
-  addNodeButton.SetPos(
-      XMFLOAT2(translation.x + padding,
-               translation.y + scale.y - addNodeButton.GetSize().y - padding));
+      XMFLOAT2(separator - padding * 2, addNodeButton.GetSize().y));
   addNodeButton.AttachTo(this);
 }

--- a/Editor/NodeEditorWindow.h
+++ b/Editor/NodeEditorWindow.h
@@ -7,12 +7,23 @@ class NodeEditorWindow : public wi::gui::Window {
 public:
   void Create(EditorComponent *editor);
 
+  struct Node {
+    wi::gui::Window window;
+    Node() = default;
+    Node(const Node &) = delete;
+    Node &operator=(const Node &) = delete;
+  };
+
   EditorComponent *editor = nullptr;
 
+  wi::vector<std::unique_ptr<Node>> nodes;
   wi::gui::Button addNodeButton;
 
   void Update(const wi::Canvas &canvas, float dt) override;
   void Render(const wi::Canvas &canvas,
               wi::graphics::CommandList cmd) const override;
   void ResizeLayout() override;
+
+private:
+  void AddNode();
 };

--- a/Editor/NodeEditorWindow.h
+++ b/Editor/NodeEditorWindow.h
@@ -9,6 +9,8 @@ public:
 
   EditorComponent *editor = nullptr;
 
+  wi::gui::Button addNodeButton;
+
   void Update(const wi::Canvas &canvas, float dt) override;
   void Render(const wi::Canvas &canvas,
               wi::graphics::CommandList cmd) const override;

--- a/Editor/NodeEditorWindow.h
+++ b/Editor/NodeEditorWindow.h
@@ -9,7 +9,9 @@ public:
 
   struct Node {
     wi::gui::Window window;
-    Node() = default;
+    wi::gui::Label label;
+    std::string name;
+    Node(const std::string &name) : name(name) {}
     Node(const Node &) = delete;
     Node &operator=(const Node &) = delete;
   };

--- a/Editor/NodeEditorWindow.h
+++ b/Editor/NodeEditorWindow.h
@@ -3,36 +3,35 @@
 class EditorComponent;
 
 // Simple node-based editor window for experimenting with IO graphs
-// Nodes are represented as small movable windows and connections are drawn between them.
-class NodeEditorWindow : public wi::gui::Window
-{
+// Nodes are represented as small movable windows and connections are drawn
+// between them.
+class NodeEditorWindow : public wi::gui::Window {
 public:
-	void Create(EditorComponent* editor);
+  void Create(EditorComponent *editor);
 
-	EditorComponent* editor = nullptr;
+  EditorComponent *editor = nullptr;
 
-	// button to add new nodes
-	wi::gui::Button addNodeButton;
+  // button to add new nodes
+  wi::gui::Button addNodeButton;
 
-        struct Node
-        {
-                wi::gui::Window window; // visual representation of the node
+  struct Node {
+    wi::gui::Window window; // visual representation of the node
 
-                Node() = default;
-                Node(const Node&) = delete;
-                Node& operator=(const Node&) = delete;
-                Node(Node&&) = default;
-                Node& operator=(Node&&) = default;
-        };
+    Node() = default;
+    Node(const Node &) = delete;
+    Node &operator=(const Node &) = delete;
+    Node(Node &&) = default;
+    Node &operator=(Node &&) = default;
+  };
 
-        // collection of nodes and links
-        wi::vector<std::unique_ptr<Node>> nodes;
-	wi::vector<std::pair<size_t, size_t>> links;
+  // collection of nodes and links
+  wi::vector<std::unique_ptr<Node>> nodes;
+  wi::vector<std::pair<size_t, size_t>> links;
 
-	void AddNode(const std::string& name, const XMFLOAT2& position);
+  void AddNode(const std::string &name, const XMFLOAT2 &position);
 
-	void Update(const wi::Canvas& canvas, float dt) override;
-	void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;
-	void ResizeLayout() override;
+  void Update(const wi::Canvas &canvas, float dt) override;
+  void Render(const wi::Canvas &canvas,
+              wi::graphics::CommandList cmd) const override;
+  void ResizeLayout() override;
 };
-

--- a/Editor/NodeEditorWindow.h
+++ b/Editor/NodeEditorWindow.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 class EditorComponent;
 
 // Simple node-based editor window for experimenting with IO graphs
@@ -13,13 +14,19 @@ public:
 	// button to add new nodes
 	wi::gui::Button addNodeButton;
 
-	struct Node
-	{
-		wi::gui::Window window; // visual representation of the node
-	};
+        struct Node
+        {
+                wi::gui::Window window; // visual representation of the node
 
-	// collection of nodes and links
-	wi::vector<Node> nodes;
+                Node() = default;
+                Node(const Node&) = delete;
+                Node& operator=(const Node&) = delete;
+                Node(Node&&) = default;
+                Node& operator=(Node&&) = default;
+        };
+
+        // collection of nodes and links
+        wi::vector<std::unique_ptr<Node>> nodes;
 	wi::vector<std::pair<size_t, size_t>> links;
 
 	void AddNode(const std::string& name, const XMFLOAT2& position);

--- a/Editor/NodeEditorWindow.h
+++ b/Editor/NodeEditorWindow.h
@@ -1,34 +1,13 @@
 #pragma once
-#include <memory>
 class EditorComponent;
 
-// Simple node-based editor window for experimenting with IO graphs
-// Nodes are represented as small movable windows and connections are drawn
-// between them.
+// Minimal node editor window mirroring Content Browser layout.
+// Functionality will be extended with actual node editing later.
 class NodeEditorWindow : public wi::gui::Window {
 public:
   void Create(EditorComponent *editor);
 
   EditorComponent *editor = nullptr;
-
-  // button to add new nodes
-  wi::gui::Button addNodeButton;
-
-  struct Node {
-    wi::gui::Window window; // visual representation of the node
-
-    Node() = default;
-    Node(const Node &) = delete;
-    Node &operator=(const Node &) = delete;
-    Node(Node &&) = default;
-    Node &operator=(Node &&) = default;
-  };
-
-  // collection of nodes and links
-  wi::vector<std::unique_ptr<Node>> nodes;
-  wi::vector<std::pair<size_t, size_t>> links;
-
-  void AddNode(const std::string &name, const XMFLOAT2 &position);
 
   void Update(const wi::Canvas &canvas, float dt) override;
   void Render(const wi::Canvas &canvas,

--- a/Editor/NodeEditorWindow.h
+++ b/Editor/NodeEditorWindow.h
@@ -1,0 +1,31 @@
+#pragma once
+class EditorComponent;
+
+// Simple node-based editor window for experimenting with IO graphs
+// Nodes are represented as small movable windows and connections are drawn between them.
+class NodeEditorWindow : public wi::gui::Window
+{
+public:
+	void Create(EditorComponent* editor);
+
+	EditorComponent* editor = nullptr;
+
+	// button to add new nodes
+	wi::gui::Button addNodeButton;
+
+	struct Node
+	{
+		wi::gui::Window window; // visual representation of the node
+	};
+
+	// collection of nodes and links
+	wi::vector<Node> nodes;
+	wi::vector<std::pair<size_t, size_t>> links;
+
+	void AddNode(const std::string& name, const XMFLOAT2& position);
+
+	void Update(const wi::Canvas& canvas, float dt) override;
+	void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;
+	void ResizeLayout() override;
+};
+


### PR DESCRIPTION
## Summary
- Introduce `NodeEditorWindow` for experimenting with node-based workflows
- Hook node editor into top menu and initialization of the editor

## Testing
- `cmake -S . -B build`
- `cmake --build build --target Editor -j 4` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b787ea0c808327a77dc32d063ed769